### PR TITLE
fix: repr attacker-controlled values in parse-failure log (log forging)

### DIFF
--- a/prtime.py
+++ b/prtime.py
@@ -149,7 +149,9 @@ def sum_hours(s, pr_id, pr_html=None):
             raise ValueError(f"disallowed node: {type(node).__name__}")
         return float(eval(compile(tree, "<sum_hours>", "eval"), {"__builtins__": {}}, {}))
     except Exception:
-        _logger.info(f"Cannot parse [{s}] in [{pr_id}] [{pr_html or ''}]")
+        # repr() the attacker-controlled values so embedded newlines can't forge
+        # extra log lines (s/pr_html come from PR body content).
+        _logger.info(f"Cannot parse [{s!r}] in [{pr_id}] [{(pr_html or '')!r}]")
     return -1.
 
 

--- a/prtime.py
+++ b/prtime.py
@@ -149,9 +149,10 @@ def sum_hours(s, pr_id, pr_html=None):
             raise ValueError(f"disallowed node: {type(node).__name__}")
         return float(eval(compile(tree, "<sum_hours>", "eval"), {"__builtins__": {}}, {}))
     except Exception:
-        # repr() the attacker-controlled values so embedded newlines can't forge
-        # extra log lines (s/pr_html come from PR body content).
-        _logger.info(f"Cannot parse [{s!r}] in [{pr_id}] [{(pr_html or '')!r}]")
+        # repr() every untrusted field so embedded newlines can't forge extra log
+        # lines: s is the ETA arithmetic string, pr_id includes the PR title (via
+        # get_pr_id), and pr_html is the PR URL. Parameterized %r keeps it lazy.
+        _logger.info("Cannot parse [%r] in [%r] [%r]", s, pr_id, pr_html or "")
     return -1.
 
 


### PR DESCRIPTION
Why:  `sum_hours` logged raw `s`/`pr_html` on parse failure; PR-body content can contain newlines, allowing forged extra log lines (flagged by Copilot on #13 after it merged).

How:  Use `!r` (repr) on `s` and `pr_html` so embedded newlines are escaped. One line, no behaviour change otherwise.