### PR TITLE
Fix deprecation and dependency warnings

### DIFF
--- a/prtime.py
+++ b/prtime.py
@@ -25,7 +25,7 @@ import shutil
 import tqdm
 from pprint import pformat
 from collections import defaultdict, OrderedDict
-from github import Github
+from github import Github, Auth
 
 from datetime import datetime, timedelta, date, timezone
 
@@ -1182,7 +1182,7 @@ if __name__ == '__main__':
     # init based on settings
     hours_row.init()
 
-    gh = Github(os.environ[gh_key])
+    gh = Github(auth=Auth.Token(os.environ[gh_key]))
 
     if flags.check_last:
         rec = re.compile(r"^(\d+)w$")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 PyGithub>=2.0
-tqdm
+# Floor clears known tqdm advisories incl. CVE-2024-34062 (CLI arg injection,
+# fixed in 4.66.3) flagged by OSV/CodeRabbit on the unconstrained entry.
+tqdm>=4.66.3
 # requests (a PyGithub dependency) only supports chardet >=3.0.2,<6.0.0.
 # Newer chardet (e.g. 7.x) trips RequestsDependencyWarning and makes requests
 # ignore charset_normalizer. Pin to the supported range.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 PyGithub>=2.0
 tqdm
+# requests (a PyGithub dependency) only supports chardet >=3.0.2,<6.0.0.
+# Newer chardet (e.g. 7.x) trips RequestsDependencyWarning and makes requests
+# ignore charset_normalizer. Pin to the supported range.
+chardet>=3.0.2,<6.0.0


### PR DESCRIPTION
Fixes the warnings seen when running the report, plus the dependency advisory raised in review. Consolidates #18 so there's a single PR to review.

**PyGithub deprecation** — `Github(os.environ[gh_key])` triggered `DeprecationWarning: Argument login_or_token is deprecated, please use auth=github.Auth.Token(...)`. Switched to the supported `Github(auth=Auth.Token(...))` API.

**requests / chardet mismatch** — `RequestsDependencyWarning: ... chardet ... doesn't match a supported version`. `requests` supports `chardet >=3.0.2,<6.0.0`; newer chardet (7.x) is outside that range, so requests warns and ignores the in-range `charset_normalizer`. Pinned `chardet>=3.0.2,<6.0.0` in `requirements.txt`.

**tqdm advisories (was #18)** — the unconstrained `tqdm` entry let pip resolve to versions with HIGH advisories (PYSEC-2017-74, GHSA-r7q7-xcjw-qx8q, and GHSA-g7vv-2v7x-gj9p / CVE-2024-34062 CLI argument injection, fixed in 4.66.3). Added a `tqdm>=4.66.3` floor.

Run `pip install -r requirements.txt` to apply the dependency pins. Tests: `pytest` — 12 passed, 30 subtests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)