### PR TITLE
Pin minimum tqdm version to clear known advisories

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 PyGithub>=2.0
-tqdm
+# Floor clears known tqdm advisories incl. CVE-2024-34062 (CLI arg injection,
+# fixed in 4.66.3) flagged by OSV/CodeRabbit on the unconstrained entry.
+tqdm>=4.66.3


### PR DESCRIPTION
Addresses the actionable CodeRabbit review comment on #17.

The `tqdm` entry in `requirements.txt` was unconstrained, so `pip install -r requirements.txt` could resolve to versions with HIGH-severity advisories flagged by OSV Scanner:

- PYSEC-2017-74
- GHSA-g7vv-2v7x-gj9p — CLI argument injection / arbitrary code execution (CVE-2024-34062, fixed in 4.66.3)
- GHSA-r7q7-xcjw-qx8q — arbitrary code execution

Added a `tqdm>=4.66.3` floor, which clears all three while still allowing patch/minor updates. Verified the locally installed tqdm (4.67.1) satisfies the floor.

Independent of #17 (which leaves the `tqdm` line untouched), so the two PRs do not conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a security vulnerability in an upstream dependency by applying a version constraint that clears known advisories, including CVE-2024-34062.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->